### PR TITLE
Fix JavaScript syntax error in app bootstrap

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,4 +1,5 @@
-(() => {`n  // TODO: Considerare una strategia di offuscamento/build per rendere piu arduo il reverse engineering del flusso JS.
+(() => {
+  // TODO: Considerare una strategia di offuscamento/build per rendere piu arduo il reverse engineering del flusso JS.
   const FG = {
     VERSION: '2025-09-24-01',
     STORAGE_KEY: 'fg_state',
@@ -242,7 +243,8 @@
     globalObserver.observe(document.body, { childList: true, subtree: true });
   }
 
-  const setupPasswordGate = (config = {}) => {`n    // TODO: Integrare popup con immagini/suoni quando gli utenti sbagliano ripetutamente la password
+  const setupPasswordGate = (config = {}) => {
+    // TODO: Integrare popup con immagini/suoni quando gli utenti sbagliano ripetutamente la password
     const overlay = document.querySelector(config.overlaySelector || '#fgPasswordOverlay');
     const form = overlay?.querySelector('form');
     const input = overlay?.querySelector(config.inputSelector || 'input[type="password"],input[type="text"]');

--- a/enigma1.html
+++ b/enigma1.html
@@ -17,7 +17,8 @@
         <p>Il messaggio cambia ad ogni tuo tentativo: il shift del cifrario Cesare si rigenera in continuazione, ma il testo in chiaro resta lo stesso.</p>
       </header>
 
-      <!-- TODO: Caricare le immagini definitive e usarle come fonte di indizi/metadati -->`n      <section class="cipher-board">
+      <!-- TODO: Caricare le immagini definitive e usarle come fonte di indizi/metadati -->
+      <section class="cipher-board">
         <div>
           <span class="cipher-label">Shift attuale:</span>
           <strong id="shiftValue">+0</strong>


### PR DESCRIPTION
## Summary
- replace literal ``n sequences with actual newlines in the main JavaScript bundle
- ensure the password gate initializer no longer throws during parsing

## Testing
- not run (static asset fix)

------
https://chatgpt.com/codex/tasks/task_e_68d50c8124e8832b97dd18c3a2002ede